### PR TITLE
fix(windows): fix test_reporter running on Windows

### DIFF
--- a/packages/test_reporter/bin/test_reporter.dart
+++ b/packages/test_reporter/bin/test_reporter.dart
@@ -61,7 +61,7 @@ Future<(Isolate, SendPort)> createReporter(
   final Directory tempDir = Directory.systemTemp.createTempSync();
 
   final (customImportLine, method, hasArgs) =
-      await getCustomReporterImport(as: 'e1') ?? ('', '', false);
+      await getCustomReporterImport(as: 'e1',path:tempDir.path) ?? ('', '', false);
   final importLine = customImportLine.isEmpty
       ? switch (reporter) {
           String package when package.contains('/') =>
@@ -109,8 +109,10 @@ Future<void> main(List<String> args, SendPort sendPort) async {
   );
 }
 ''';
-
-  final File tempFile = File(p.join(tempDir.path, '_reporter_temp_.dart'));
+  String absoluteFilePath = File(p.join(tempDir.path, '_reporter_temp_.dart')).absolute.path;
+  /// Ensure the parent directory exists
+  Directory(p.dirname(absoluteFilePath)).createSync(recursive: true);
+  final File tempFile = File(absoluteFilePath);
   await tempFile.writeAsString(code);
 
   final ReceivePort receivePort = ReceivePort();
@@ -137,10 +139,13 @@ Future<void> main(List<String> args, SendPort sendPort) async {
 }
 
 Future<(String, String, bool)?> getCustomReporterImport(
-    {String as = ''}) async {
+    {String as = '',String path=''}) async {
   final customReporter = File(p.join('test', 'reporter.dart'));
+  String relativePath = _posixRelative(customReporter.absolute.path, from:path);
+  /// Get the absolute path and replace '\' with '\\'
+  final sanitizedPath = relativePath.replaceAll(r'\', r'\\');
   final customReporterImportLine =
-      "import '${customReporter.absolute.path}'${as.isNotEmpty ? 'as $as' : ''};";
+      "import '$sanitizedPath'${as.isNotEmpty ? 'as $as' : ''};";
 
   if (!await customReporter.exists()) return null;
 
@@ -159,3 +164,22 @@ Future<(String, String, bool)?> getCustomReporterImport(
 
   return null;
 }
+/// This creates a relative path from `from` to `input`, the output being a
+/// posix path on all platforms.
+/// by talel briki 15/05/2025
+String _posixRelative(String input, {String from = ""}) {
+  // Use the appropriate context for Windows
+  final p.Context context = p.Context(style: p.Style.windows);
+
+  // Ensure the input and "from" paths are absolute
+  final String absInputPath = File(input).absolute.path;
+  final String absFromPath = Directory(from).absolute.path;
+
+  // Print the resolved absolute paths
+
+  // Compute the relative path
+  final String relativePath = context.relative(absInputPath, from: absFromPath);
+
+  return relativePath;
+}
+

--- a/packages/test_reporter/lib/src/runner/test_runner.dart
+++ b/packages/test_reporter/lib/src/runner/test_runner.dart
@@ -58,10 +58,15 @@ Stream<TestEvent> flutterTest({
   Map<String, String>? environment,
   bool runInShell = false,
   StartProcess startProcess = Process.start,
-}) {
-  return _runTestProcess(
-    () => startProcess(
-      'flutter',
+}) async*{
+  ///extract flutter path to run command
+  final flutterPath = await getActiveFlutterPath();
+  if (flutterPath == null) {
+    throw Exception('Flutter executable not found in PATH.');
+  }
+  yield* _runTestProcess(
+        () => startProcess(
+      flutterPath,
       ['test', ...?arguments, '--reporter=json'],
       environment: environment,
       workingDirectory: workingDirectory,
@@ -144,3 +149,33 @@ extension on Stream<List<int>> {
     }
   }
 }
+///get flutter path
+/// by talel briki 15/05/2025
+Future<String?> getActiveFlutterPath() async {
+  try {
+    final result = await Process.run(
+      Platform.isWindows ? 'flutter.bat' : 'flutter',
+      ['--version', '--machine'],
+    );
+
+
+    if (result.exitCode == 0) {
+      final output = result.stdout as String;
+      final jsonMap = jsonDecode(output);
+
+      final flutterRoot = jsonMap['flutterRoot'];
+
+      if (flutterRoot != null) {
+        final flutterPath = Platform.isWindows
+            ? '$flutterRoot\\bin\\flutter.bat'
+            : '$flutterRoot/bin/flutter';
+        return flutterPath;
+      }
+    }
+  } catch (e) {
+    print('Failed to detect Flutter path: $e');
+  }
+
+  return null;
+}
+


### PR DESCRIPTION
- when creating a temporary file and adding import of reporter.dart to change path if not provided with relative path 
- before running flutter test command extract flutter path so command doesn't fail